### PR TITLE
run keystone from /

### DIFF
--- a/keystone-devel/Dockerfile
+++ b/keystone-devel/Dockerfile
@@ -28,7 +28,7 @@ RUN ["cp", "etc/policy.json", "/etc/keystone/"]
 EXPOSE 5000
 EXPOSE 35357
 
-ADD update_and_start_keystone /opt/
+ADD update_and_start_keystone /
 
 WORKDIR /
-ENTRYPOINT ["/opt/update_and_start_keystone"]
+ENTRYPOINT ["/update_and_start_keystone"]


### PR DESCRIPTION
Not sure if this would work.  but... alot of times we see executables in the / directory, rather
than pretending to follow linux multitenant conventions.
this helps enforce the microservice convention.